### PR TITLE
fix: tests should be passed before merge

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -22,4 +22,4 @@ jobs:
           deno-version: v2.x
 
       - name: Run tests
-        run: deno test -A
+        run: deno test -A --unstable-kv


### PR DESCRIPTION
## Description
`--unstable-kv` is needed to use deno.kv()